### PR TITLE
tor: pass explicitly given control ports to starter

### DIFF
--- a/tor/tor.go
+++ b/tor/tor.go
@@ -207,6 +207,8 @@ func (t *Tor) startProcess(ctx context.Context, conf *StartConf) error {
 			return err
 		}
 		args = append(args, "--ControlPort", "auto", "--ControlPortWriteToFile", controlPortFile.Name())
+	} else {
+		args = append(args, "--ControlPort", strconv.Itoa(conf.ControlPort))
 	}
 	// Start process with the args
 	var processCtx context.Context


### PR DESCRIPTION
If the user explicitly supplies a control port to `tor.StartConf`, you currently don't pass that along to tor. The end result is that tor does not open any control port at all. The fix is relatively straightforward, always pass the `--ControlPort` flag.