### PR TITLE
Modified parsing of eventcode in relayAsyncEvents

### DIFF
--- a/control/cmd_event.go
+++ b/control/cmd_event.go
@@ -271,11 +271,17 @@ func (c *Conn) relayAsyncEvents(resp *Response) {
 	var dataArray []string
 	if len(resp.Data) == 1 {
 		// If there is a single line of data, first line of it is the code, rest of the first line is data
-		firstNewline := strings.Index(resp.Data[0], "\r\n")
-		if firstNewline == -1 {
+		// Find the index which specfies the char after the event code, either space or newline
+		index := strings.Index(resp.Data[0], " ")
+		if index == -1 {
+			index = strings.Index(resp.Data[0], "\r\n")
+		}
+
+		if index == -1 {
 			return
 		}
-		code, data = resp.Data[0][:firstNewline], resp.Data[0][firstNewline+2:]
+
+		code, data = resp.Data[0][:index], resp.Data[0][index+2:]
 	} else if len(resp.Data) > 0 {
 		// If there are multiple lines, the entire first line is the code
 		code, dataArray = resp.Data[0], resp.Data[1:]

--- a/control/cmd_event.go
+++ b/control/cmd_event.go
@@ -275,10 +275,9 @@ func (c *Conn) relayAsyncEvents(resp *Response) {
 		index := strings.Index(resp.Data[0], " ")
 		if index == -1 {
 			index = strings.Index(resp.Data[0], "\r\n")
-		}
-
-		if index == -1 {
-			return
+			if index == -1 {
+				return
+			}
 		}
 
 		code, data = resp.Data[0][:index], resp.Data[0][index+2:]


### PR DESCRIPTION
fixes #8 

The eventcode HS_DESC_CONTENT is followed by a space and then a bunch of other data, but the code currently assumes that the eventcode is just followed by a newline.  The current change fixes this for the eventcode in question, however i haven't tested this with many other events, so not 100% sure if this breaks anything. 