### PR TITLE
fix race condition in control/conn/SendRequest

### DIFF
--- a/control/conn.go
+++ b/control/conn.go
@@ -56,12 +56,14 @@ func (c *Conn) SendRequest(format string, args ...interface{}) (*Response, error
 	if c.debugEnabled() {
 		c.debugf("Write line: %v", fmt.Sprintf(format, args...))
 	}
+
+	c.readLock.Lock()
+	defer c.readLock.Unlock()
+
 	id, err := c.conn.Cmd(format, args...)
 	if err != nil {
 		return nil, err
 	}
-	c.readLock.Lock()
-	defer c.readLock.Unlock()
 	c.conn.StartResponse(id)
 	defer c.conn.EndResponse(id)
 	// Get the first non-async response


### PR DESCRIPTION
Integration tests in cwtch.im (https://git.openprivacy.ca/cwtch.im/cwtch/src/master/testing/cwtch_peer_server_intergration_test.go) discovered a race condition.

You allow all threads to write and get an id, THEN get a lock to read. The unordered writes (Cmd) don't seem to match the ordered reads so my integ test (4 threads cross connecting) jams up usually with one thread getting the SendRequest lock and then waiting forever on 	c.conn.StartResponse(id)
 while the rest wait for the lock.

Just moving this lock above the Cmd/write fixes this