### PR TITLE
Force linking against pthreads statically

### DIFF
--- a/process/embedded/tor-0.3.5/process.go
+++ b/process/embedded/tor-0.3.5/process.go
@@ -24,7 +24,7 @@ import (
 #cgo LDFLAGS: -L${SRCDIR}/../../../../tor-static/xz/dist/lib -llzma
 #cgo LDFLAGS: -L${SRCDIR}/../../../../tor-static/zlib/dist/lib -lz
 #cgo LDFLAGS: -L${SRCDIR}/../../../../tor-static/openssl/dist/lib -lssl -lcrypto
-#cgo windows LDFLAGS: -lws2_32 -lcrypt32 -lgdi32 -liphlpapi
+#cgo windows LDFLAGS: -lws2_32 -lcrypt32 -lgdi32 -liphlpapi -Wl,-Bstatic -lpthread
 #cgo !windows LDFLAGS: -lm
 
 #include <stdlib.h>


### PR DESCRIPTION
when i went to compile a test project with bine on windows+msys2, the produced binary had dynamic imports for libwinpthread-1.dll. This library is required in the library path or pwd for the binary to run at all, and no visible error is produced. The binary runs fine in the msys environment, because this library is present, but on raw windows it doesnt.
This needs to be tested to verify its not just a peculiarity in my build environ, but these two flags, in this order, removed the import in the exe, and the binary is now truly standalone.

![img](https://image.ibb.co/knj3VV/image.png)

All the other libs are part of windows afaik.