### PR TITLE
tor: fix folder permission (+x) for auto-created datadir

### DIFF
--- a/tor/tor.go
+++ b/tor/tor.go
@@ -161,7 +161,7 @@ func Start(ctx context.Context, conf *StartConf) (*Tor, error) {
 		}
 		tor.Debugf("Created temp data directory at: %v", tor.DataDir)
 		tor.DeleteDataDirOnClose = !conf.RetainTempDataDir
-	} else if err := os.MkdirAll(tor.DataDir, 0600); err != nil {
+	} else if err := os.MkdirAll(tor.DataDir, 0700); err != nil {
 		return nil, fmt.Errorf("Unable to create data dir: %v", err)
 	}
 


### PR DESCRIPTION
If I specify a non-existing folder to `tor.Start`, the library will create it:

```
tor.Start(nil, &tor.StartConf{ProcessCreator: libtor.Creator, DataDir: "/tmp/tordir"})
```

 Unfortunately it creates it without the executable permission:

```
$ ls -l /tmp/ | grep tordir
drw------- 2 karalabe karalabe 4096 Dec  5 13:59 tordir
```

Which of course results in a permission error when accessing it:

```
open /tmp/tordir/torrc-501927786: permission denied
```

This PR fixes the folder by adding the missing executable bit.